### PR TITLE
Bump `go-cpy` to `v3.11.2`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.nhat.io/cpy/v3 v3.11.1
+	go.nhat.io/cpy/v3 v3.11.2
 	go.nhat.io/once v0.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-go.nhat.io/cpy/v3 v3.11.1 h1:a3BnCcrDaBeTAJH93GRJXgjYhaP7dzN9igg5D5R20gE=
-go.nhat.io/cpy/v3 v3.11.1/go.mod h1:ZB/O/aVbrq5cbn+3AE04Ae5HeplqFZ3jFgo80MwbR24=
+go.nhat.io/cpy/v3 v3.11.2 h1:6+9rz9UAMg2j3ryZ/r7m9KMTDua88uJcBjU+lHzJ+Jg=
+go.nhat.io/cpy/v3 v3.11.2/go.mod h1:i/ZDT/zYfaqSIXteB3ZXum49Hpi2wcRmYDLX6/Yg57E=
 go.nhat.io/once v0.3.0 h1:AwMxs8GWXhWS30Al5YbxDRvUwSo1XmgBNn1dr/x/KCQ=
 go.nhat.io/once v0.3.0/go.mod h1:1nB6JRBNV5S3GC/UIUtNDpfXxjlEOh55WyD2DxgQrsE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Description

Bump `go-cpy` to `v3.11.2`